### PR TITLE
記事修正用のリンクが404になっているので修正

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -26,7 +26,7 @@ export const shared = defineConfig({
       copyright: 'Copyright @ 2024-present authors'
     },
     editLink: {
-      pattern: 'https://github.com/lilxyzw/matome/edit/docs/docs/:path',
+      pattern: 'https://github.com/lilxyzw/matome/edit/main/docs/:path',
       text: 'Edit this page on GitHub'
     },
     search: {


### PR DESCRIPTION
ブランチ名が間違っていたので修正しました

## 事象
例えば
https://lilxyzw.github.io/matome/ja/common/installwithvpm.html
のページにて、リンクが以下のようになっていて、開くと404になってしまっています。

> [Edit this page on GitHub](https://github.com/lilxyzw/matome/edit/docs/docs/ja/common/installwithvpm.md)
<img width="1163" alt="スクリーンショット 2024-12-24 0 49 18" src="https://github.com/user-attachments/assets/5d2dfac6-a94d-4d2b-a7ef-cb6ca7247b32" />

